### PR TITLE
fix: requirements.txt misprint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pycryptodome==3.15.0
 vk==3.0
 vk-api==11.9.9
 beautifulsoup4==4.11.1
-requests=2.28.1
+requests==2.28.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ vk==3.0
 vk-api==11.9.9
 beautifulsoup4==4.11.1
 requests==2.28.1
+aiohttp
 


### PR DESCRIPTION
`=` is not supported in `requirements.txt`. I fixed it
before, running `python3 -m pip install -r requirements.txt` raised an error:
```python
ERROR: Invalid requirement: 'requests=2.28.1' (from line 6 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```

Please, review this PR